### PR TITLE
Fix license

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "neusta/converter-bundle",
   "type": "symfony-bundle",
   "description": "Allows to easily use the Converter & Populator design pattern for transformations from one universe to another",
-  "license": "GPL-3.0-or-later",
+  "license": "MIT",
   "authors": [
     {
       "name": "team neusta GmbH",


### PR DESCRIPTION
The [LICENSE](https://github.com/teamneusta/converter-bundle/blob/main/LICENSE) file contains a MIT license, while composer said it's GPLv3+

I assume the LICENSE file tells the truth.