### PR TITLE
Prefix services

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -6,6 +6,6 @@ services:
     ############################################################
     # Default Converter
     ############################################################
-    default.converter:
+    neusta_converter.default_converter:
         abstract: true
         class: Neusta\ConverterBundle\Converter\DefaultConverter

--- a/docs/cached-converter.md
+++ b/docs/cached-converter.md
@@ -36,12 +36,19 @@ To put things together declare the following cached converter in your Symfony co
 
 ```yaml
 person.converter:
-  parent: 'default.converter.with.cache'
+  parent: 'neusta_converter.default_converter'
   public: true
   arguments:
     $factory: '@YourNamespace\PersonFactory'
     $populators:
       - '@YourNamespace\PersonNamePopulator'
+    $cacheManagement: '@user.cache_management'
+
+person.converter.cached:
+  class: Neusta\ConverterBundle\Converter\DefaultCachedConverter
+  decorates: person.converter
+  arguments:
+    $inner: '@.inner'
     $cacheManagement: '@user.cache_management'
 
 user.cache_management:

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -101,7 +101,7 @@ To put things together declare the following converter in your Symfony config:
 
 ```yaml
 person.converter:
-  parent: 'default.converter'
+  parent: 'neusta_converter.default_converter'
   public: true
   arguments:
     $factory: '@YourNamespace\PersonFactory'

--- a/tests/app/config/services.yaml
+++ b/tests/app/config/services.yaml
@@ -10,7 +10,7 @@ services:
         public: true
 
     test.person.converter: &test-person-converter
-        parent: 'default.converter'
+        parent: 'neusta_converter.default_converter'
         public: true
         arguments:
             $factory: '@Neusta\ConverterBundle\Tests\Fixtures\Factory\PersonFactory'


### PR DESCRIPTION
Services in bundles should be prefixed, according to [Symfony's best practices for bundles](https://symfony.com/doc/5.4/bundles/best_practices.html#services).

> **Note**
> This is a BC break. But please wait with releasing a new major, as there are some more to come 😉 