### PR TITLE
Fix cached converter

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -9,14 +9,3 @@ services:
     default.converter:
         abstract: true
         class: Neusta\ConverterBundle\Converter\DefaultConverter
-
-    ############################################################
-    # Default Converter with Cache
-    ############################################################
-    default.converter.with.cache:
-        abstract: true
-        class: Neusta\ConverterBundle\Converter\DefaultCachedConverter
-        decorates: default.converter
-        arguments:
-            $inner: '@.inner'
-

--- a/src/Converter/DefaultCachedConverter.php
+++ b/src/Converter/DefaultCachedConverter.php
@@ -34,7 +34,7 @@ class DefaultCachedConverter implements CachedConverter
             return $this->cacheManagement->get($source);
         }
 
-        $target = $this->inner->convert($source);
+        $target = $this->inner->convert($source, $ctx);
 
         $this->cacheManagement->writeInCache($target, $source);
 

--- a/tests/app/config/services.yaml
+++ b/tests/app/config/services.yaml
@@ -9,7 +9,7 @@ services:
         alias: service_container
         public: true
 
-    test.person.converter:
+    test.person.converter: &test-person-converter
         parent: 'default.converter'
         public: true
         arguments:
@@ -18,11 +18,14 @@ services:
                 - '@Neusta\ConverterBundle\Tests\Fixtures\Populator\PersonNamePopulator'
 
     test.person.converter.with.cache:
-        parent: 'default.converter.with.cache'
-        public: true
+        <<: *test-person-converter
+
+    test.person.converter.with.cache.decorator:
+        class: Neusta\ConverterBundle\Converter\CachedConverter
+        decorates: test.person.converter.with.cache
         arguments:
             $inner: '@.inner'
-            $cacheManagement: '@Neusta\ConverterBundle\CacheManagement\DefaultCacheManagement'
+            $cacheManagement: '@user.cache_management'
 
     Neusta\ConverterBundle\Tests\Fixtures\Populator\PersonNamePopulator: ~
 
@@ -30,6 +33,7 @@ services:
 
     Neusta\ConverterBundle\Tests\Fixtures\CacheManagement\UserKeyFactory: ~
 
-    Neusta\ConverterBundle\CacheManagement\DefaultCacheManagement:
+    user.cache_management:
+        class: Neusta\ConverterBundle\CacheManagement\DefaultCacheManagement
         arguments:
             $keyFactory: '@Neusta\ConverterBundle\Tests\Fixtures\CacheManagement\UserKeyFactory'


### PR DESCRIPTION
#10 was broken. This fixes it.

* Pass the context to the cached converter
* Fix test service config for cached converter
* Remove abstract cached converter (I don't think abstract services can be used with decorators)