### PR TITLE
Add `.gitattributes` to shrink the dist size

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,16 @@
+/.github/ export-ignore
+/bin/ export-ignore
+/docs/ export-ignore
+/tests/ export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore
+/.php-cs-fixer.php export-ignore
+/CONTRIBUTING.md export-ignore
+/depfile.yaml export-ignore
+/docker-compose.yaml export-ignore
+/Dockerfile export-ignore
+/php.ini export-ignore
+/phpstan.neon export-ignore
+/phpunit.xml.dist export-ignore
+/sonar-project.properties export-ignore
+/sonar-scanner.sh export-ignore


### PR DESCRIPTION
Removes unnecessary stuff from the `dist` package.