### PR TITLE
Populator using a converter to populate

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -23,3 +23,7 @@ services:
     neusta_converter.same_property_populator:
         abstract: true
         class: Neusta\ConverterBundle\Populator\SamePropertyPopulator
+
+    neusta_converter.converter_populator:
+        abstract: true
+        class: Neusta\ConverterBundle\Populator\ConverterPopulator

--- a/src/Exception/ConverterException.php
+++ b/src/Exception/ConverterException.php
@@ -4,9 +4,7 @@ declare(strict_types=1);
 
 namespace Neusta\ConverterBundle\Exception;
 
-use Exception;
-
-class ConverterException extends Exception
+class ConverterException extends \Exception
 {
 
 }

--- a/src/Exception/PopulationException.php
+++ b/src/Exception/PopulationException.php
@@ -4,24 +4,18 @@ declare(strict_types=1);
 
 namespace Neusta\ConverterBundle\Exception;
 
-use Exception;
-use Throwable;
-
-class PopulationException extends Exception
+class PopulationException extends \Exception
 {
-    public function __construct(
-        private ?string $sourcePropertyName = null,
-        private ?string $targetPropertyName = null,
-        string          $message = "",
-        int             $code = 0,
-        ?Throwable      $previous = null
-    )
+    public function __construct(string $sourcePropertyName, string $targetPropertyName, \Throwable $previous)
     {
-        parent::__construct($message, $code, $previous);
-        $this->message = sprintf("Population Exception (%s -> %s): %s",
-            $this->sourcePropertyName,
-            $this->targetPropertyName,
-            $this->message
+        parent::__construct(
+            sprintf("Population Exception (%s -> %s): %s",
+                $sourcePropertyName,
+                $targetPropertyName,
+                $previous->getMessage(),
+            ),
+            0,
+            $previous,
         );
     }
 }

--- a/src/Exception/PopulationException.php
+++ b/src/Exception/PopulationException.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neusta\ConverterBundle\Exception;
+
+use Exception;
+use Throwable;
+
+class PopulationException extends Exception
+{
+    public function __construct(
+        private ?string $sourcePropertyName = null,
+        private ?string $targetPropertyName = null,
+        string          $message = "",
+        int             $code = 0,
+        ?Throwable      $previous = null
+    )
+    {
+        parent::__construct($message, $code, $previous);
+        $this->message = sprintf("Population Exception (%s -> %s): %s",
+            $this->sourcePropertyName,
+            $this->targetPropertyName,
+            $this->message
+        );
+    }
+}

--- a/src/Exception/PropertyException.php
+++ b/src/Exception/PropertyException.php
@@ -6,10 +6,10 @@ namespace Neusta\ConverterBundle\Exception;
 
 class PropertyException extends \Exception
 {
-    public function __construct(string $propertyName, \Throwable $previous)
+    public function __construct(string $propertyName, ?string $message = null, ?\Throwable $previous = null)
     {
         parent::__construct(
-            sprintf("Property Exception <%s>: %s", $propertyName, $previous->getMessage()),
+            sprintf("Property Exception <%s>: %s", $propertyName, $message ?? $previous?->getMessage() ?? ''),
             0,
             $previous,
         );

--- a/src/Exception/PropertyException.php
+++ b/src/Exception/PropertyException.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neusta\ConverterBundle\Exception;
+
+use Exception;
+use Throwable;
+
+class PropertyException extends Exception
+{
+    public function __construct(
+        ?string    $propertyName = null,
+        string     $message = "",
+        int        $code = 0,
+        ?Throwable $previous = null
+    )
+    {
+        parent::__construct($message, $code, $previous);
+        $this->message = sprintf("Property Exception <%s>: %s", $propertyName, $this->message);
+    }
+}

--- a/src/Exception/PropertyException.php
+++ b/src/Exception/PropertyException.php
@@ -4,19 +4,14 @@ declare(strict_types=1);
 
 namespace Neusta\ConverterBundle\Exception;
 
-use Exception;
-use Throwable;
-
-class PropertyException extends Exception
+class PropertyException extends \Exception
 {
-    public function __construct(
-        ?string    $propertyName = null,
-        string     $message = "",
-        int        $code = 0,
-        ?Throwable $previous = null
-    )
+    public function __construct(string $propertyName, \Throwable $previous)
     {
-        parent::__construct($message, $code, $previous);
-        $this->message = sprintf("Property Exception <%s>: %s", $propertyName, $this->message);
+        parent::__construct(
+            sprintf("Property Exception <%s>: %s", $propertyName, $previous->getMessage()),
+            0,
+            $previous,
+        );
     }
 }

--- a/src/Populator/ConverterPopulator.php
+++ b/src/Populator/ConverterPopulator.php
@@ -7,7 +7,6 @@ namespace Neusta\ConverterBundle\Populator;
 use Neusta\ConverterBundle\Converter\Converter;
 use Neusta\ConverterBundle\Exception\PopulationException;
 use Neusta\ConverterBundle\Property\PropertyValueExtractor;
-use ReflectionProperty;
 
 /**
  * A populator which uses a converter for an object of type S with a certain field
@@ -44,5 +43,4 @@ class ConverterPopulator implements Populator
             throw new PopulationException($this->sourcePropertyName, $this->targetPropertyName, $exception);
         }
     }
-
 }

--- a/src/Populator/ConverterPopulator.php
+++ b/src/Populator/ConverterPopulator.php
@@ -27,10 +27,9 @@ class ConverterPopulator implements Populator
      */
     public function __construct(
         private Converter $converter,
-        private string    $sourcePropertyName,
-        private string    $targetPropertyName,
-    )
-    {
+        private string $sourcePropertyName,
+        private string $targetPropertyName,
+    ) {
     }
 
     /**
@@ -42,7 +41,7 @@ class ConverterPopulator implements Populator
             $sourceValue = PropertyValueExtractor::extractValue($source, $this->sourcePropertyName);
             $target->{'set' . ucfirst($this->targetPropertyName)}($this->converter->convert($sourceValue));
         } catch (\Throwable $exception) {
-            throw new PopulationException($this->sourcePropertyName, $this->targetPropertyName, $exception->getMessage());
+            throw new PopulationException($this->sourcePropertyName, $this->targetPropertyName, $exception);
         }
     }
 

--- a/src/Populator/ConverterPopulator.php
+++ b/src/Populator/ConverterPopulator.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neusta\ConverterBundle\Populator;
+
+use Neusta\ConverterBundle\Converter\Converter;
+use Neusta\ConverterBundle\Exception\PopulationException;
+
+/**
+ * @template S of object
+ * @template T of object
+ * @template U of object
+ * @template V of object
+ * @template C of object
+ * @implements Populator<S, T, C>
+ */
+class ConverterPopulator implements Populator
+{
+    /**
+     * @param Converter<U, V, C> $converter
+     */
+    public function __construct(
+        private Converter $converter,
+        private string    $sourcePropertyName,
+        private string    $targetPropertyName,
+    )
+    {
+    }
+
+    /**
+     * @throws PopulationException
+     */
+    public function populate(object $target, object $source, ?object $ctx = null): void
+    {
+        $sourceValue = null;
+        try {
+            foreach (['get', 'is', 'has'] as $prefix) {
+                if (method_exists($source, $prefix . ucfirst($this->sourcePropertyName))) {
+                    $sourceValue = $source->{$prefix . ucfirst($this->sourcePropertyName)}();
+                    break;
+                }
+            }
+            $target->{'set' . ucfirst($this->targetPropertyName)}($this->converter->convert($sourceValue));
+        } catch (\Throwable $exception) {
+            throw new PopulationException($this->sourcePropertyName, $this->targetPropertyName, $exception->getMessage());
+        }
+    }
+
+}

--- a/src/Populator/ConverterPopulator.php
+++ b/src/Populator/ConverterPopulator.php
@@ -10,6 +10,9 @@ use Neusta\ConverterBundle\Property\PropertyValueExtractor;
 use ReflectionProperty;
 
 /**
+ * A populator which uses a converter for an object of type S with a certain field
+ * containing an object of type U which should be converted into V and populated into a field of T object.
+ *
  * @template S of object
  * @template T of object
  * @template U of object

--- a/src/Populator/ConverterPopulator.php
+++ b/src/Populator/ConverterPopulator.php
@@ -6,6 +6,8 @@ namespace Neusta\ConverterBundle\Populator;
 
 use Neusta\ConverterBundle\Converter\Converter;
 use Neusta\ConverterBundle\Exception\PopulationException;
+use Neusta\ConverterBundle\Property\PropertyValueExtractor;
+use ReflectionProperty;
 
 /**
  * @template S of object
@@ -33,14 +35,8 @@ class ConverterPopulator implements Populator
      */
     public function populate(object $target, object $source, ?object $ctx = null): void
     {
-        $sourceValue = null;
         try {
-            foreach (['get', 'is', 'has'] as $prefix) {
-                if (method_exists($source, $prefix . ucfirst($this->sourcePropertyName))) {
-                    $sourceValue = $source->{$prefix . ucfirst($this->sourcePropertyName)}();
-                    break;
-                }
-            }
+            $sourceValue = PropertyValueExtractor::extractValue($source, $this->sourcePropertyName);
             $target->{'set' . ucfirst($this->targetPropertyName)}($this->converter->convert($sourceValue));
         } catch (\Throwable $exception) {
             throw new PopulationException($this->sourcePropertyName, $this->targetPropertyName, $exception->getMessage());

--- a/src/Populator/SamePropertyPopulator.php
+++ b/src/Populator/SamePropertyPopulator.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Neusta\ConverterBundle\Populator;
 
+use Neusta\ConverterBundle\Property\PropertyValueExtractor;
+
 /**
  * @template S of object
  * @template T of object
@@ -19,18 +21,10 @@ class SamePropertyPopulator implements Populator
 
     public function populate(object $target, object $source, ?object $ctx = null): void
     {
-        $valueToSet = null;
-        $valueHasBeenSet = false;
+        $valueToSet = PropertyValueExtractor::extractValue($source, $this->propertyName);
 
-        foreach (['get', 'is', 'has'] as $prefix) {
-            if (method_exists($source, $prefix . ucfirst($this->propertyName))) {
-                $valueToSet = $source->{$prefix . ucfirst($this->propertyName)}();
-                $valueHasBeenSet = true;
-                break;
-            }
-        }
 
-        if ($valueHasBeenSet
+        if ($valueToSet
             && method_exists($target, 'set' . ucfirst($this->propertyName))
             && $this->isSameType($target, $source)
         ) {

--- a/src/Property/PropertyValueExtractor.php
+++ b/src/Property/PropertyValueExtractor.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neusta\ConverterBundle\Property;
+
+use Neusta\ConverterBundle\Exception\PropertyException;
+
+class PropertyValueExtractor
+{
+    /**
+     * @throws PropertyException
+     */
+    public static function extractValue(object $source, string $propertyName): mixed
+    {
+        try {
+            foreach (['get', 'is', 'has'] as $prefix) {
+                if (method_exists($source, $prefix . ucfirst($propertyName))) {
+                    return $source->{$prefix . ucfirst($propertyName)}();
+                }
+            }
+        } catch (\Throwable $exception) {
+            throw new PropertyException($propertyName, $exception->getMessage(), $exception->getCode(), $exception);
+        }
+        return null;
+    }
+}

--- a/src/Property/PropertyValueExtractor.php
+++ b/src/Property/PropertyValueExtractor.php
@@ -20,7 +20,7 @@ class PropertyValueExtractor
                 }
             }
         } catch (\Throwable $exception) {
-            throw new PropertyException($propertyName, $exception->getMessage(), $exception->getCode(), $exception);
+            throw new PropertyException($propertyName, $exception);
         }
         return null;
     }

--- a/src/Property/PropertyValueExtractor.php
+++ b/src/Property/PropertyValueExtractor.php
@@ -20,8 +20,9 @@ class PropertyValueExtractor
                 }
             }
         } catch (\Throwable $exception) {
-            throw new PropertyException($propertyName, $exception);
+            throw new PropertyException($propertyName, previous: $exception);
         }
-        return null;
+
+        throw new PropertyException($propertyName, 'no accessor found');
     }
 }

--- a/tests/Fixtures/Factory/AddressFactory.php
+++ b/tests/Fixtures/Factory/AddressFactory.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neusta\ConverterBundle\Tests\Fixtures\Factory;
+
+use Neusta\ConverterBundle\Converter\DefaultConverterContext;
+use Neusta\ConverterBundle\Factory\TargetTypeFactory;
+use Neusta\ConverterBundle\Tests\Fixtures\Model\PersonAddress;
+
+/**
+ * @implements TargetTypeFactory<PersonAddress, DefaultConverterContext>
+ */
+class AddressFactory implements TargetTypeFactory
+{
+    public function create(?object $ctx = null): PersonAddress
+    {
+        return new PersonAddress();
+    }
+}

--- a/tests/Fixtures/Model/UnknownType.php
+++ b/tests/Fixtures/Model/UnknownType.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neusta\ConverterBundle\Tests\Fixtures\Model;
+
+class UnknownType
+{
+
+}

--- a/tests/Fixtures/Model/User.php
+++ b/tests/Fixtures/Model/User.php
@@ -12,6 +12,8 @@ class User
     private string $fullName;
     private Address $address;
 
+    private UnknownType $fieldWithUnknownType;
+
     public function getUuid(): int
     {
         return $this->uuid;
@@ -67,6 +69,17 @@ class User
     public function setAddress(Address $address): User
     {
         $this->address = $address;
+        return $this;
+    }
+
+    public function getFieldWithUnknownType(): UnknownType
+    {
+        return $this->fieldWithUnknownType;
+    }
+
+    public function setFieldWithUnknownType(UnknownType $fieldWithUnknownType): User
+    {
+        $this->fieldWithUnknownType = $fieldWithUnknownType;
         return $this;
     }
 }

--- a/tests/Fixtures/Populator/AddressPopulator.php
+++ b/tests/Fixtures/Populator/AddressPopulator.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neusta\ConverterBundle\Tests\Fixtures\Populator;
+
+use Neusta\ConverterBundle\Converter\DefaultConverterContext;
+use Neusta\ConverterBundle\Populator\Populator;
+use Neusta\ConverterBundle\Tests\Fixtures\Model\PersonAddress;
+use Neusta\ConverterBundle\Tests\Fixtures\Model\Address;
+
+/**
+ * @implements Populator<Address, PersonAddress, DefaultConverterContext>
+ */
+class AddressPopulator implements Populator
+{
+    public function populate(object $target, object $source, ?object $ctx = null): void
+    {
+        $target->setStreet($source->getStreet());
+        $target->setStreetNo($source->getStreetNo());
+        $target->setPostalCode($source->getPostalCode());
+        $target->setCity($source->getCity());
+    }
+}

--- a/tests/Populator/PersonAddressPopulatorIntegrationTest.php
+++ b/tests/Populator/PersonAddressPopulatorIntegrationTest.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neusta\ConverterBundle\Tests\Populator;
+
+use Neusta\ConverterBundle\Converter\DefaultConverterContext;
+use Neusta\ConverterBundle\Exception\PopulationException;
+use Neusta\ConverterBundle\Populator\Populator;
+use Neusta\ConverterBundle\Tests\BundleKernelTestCase;
+use Neusta\ConverterBundle\Tests\Fixtures\Model\Address;
+use Neusta\ConverterBundle\Tests\Fixtures\Model\Person;
+use Neusta\ConverterBundle\Tests\Fixtures\Model\PersonAddress;
+use Neusta\ConverterBundle\Tests\Fixtures\Model\UnknownType;
+use Neusta\ConverterBundle\Tests\Fixtures\Model\User;
+use Neusta\ConverterBundle\Tests\Fixtures\Populator\PersonAddressPopulator;
+
+class PersonAddressPopulatorIntegrationTest extends BundleKernelTestCase
+{
+    /** @var Populator<User, Person, DefaultConverterContext> $populator */
+    private Populator $populator;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+    }
+
+    public function testPopulate_regular_case(): void
+    {
+        $this->populator = $this->getContainer()->get('test.person.address.populator');
+        $address = (new Address())
+            ->setCity('Bremen')
+            ->setPostalCode('28217')
+            ->setStreet('Konsul-Smidt-Straße')
+            ->setStreetNo('24');
+
+        $user = (new User())->setAddress($address);
+
+        $person = (new Person())->setAddress(new PersonAddress());
+
+        $this->populator->populate($person, $user);
+
+        self::assertEquals('24', $person->getAddress()->getStreetNo());
+    }
+    public function testPopulate_wrong_source_type(): void
+    {
+        $this->populator = $this->getContainer()->get('test.person.wrong.source.type.populator');
+
+        $user = (new User())->setFieldWithUnknownType(new UnknownType());
+
+        $person = (new Person())->setAddress(new PersonAddress());
+
+        $this->expectException(PopulationException::class);
+        $this->expectExceptionMessageMatches("/Population Exception \(fieldWithUnknownType -> address\): (.*)/");
+        $this->populator->populate($person, $user);
+
+        self::assertEquals('24', $person->getAddress()->getStreetNo());
+    }
+    public function testPopulate_wrong_converter(): void
+    {
+        $this->populator = $this->getContainer()->get('test.person.wrong.converter.populator');
+        $address = (new Address())
+            ->setCity('Bremen')
+            ->setPostalCode('28217')
+            ->setStreet('Konsul-Smidt-Straße')
+            ->setStreetNo('24');
+
+        $user = (new User())->setAddress($address);
+
+        $person = (new Person())->setAddress(new PersonAddress());
+
+        $this->expectException(PopulationException::class);
+        $this->expectExceptionMessageMatches("/Population Exception \(address -> address\): (.*)/");
+        $this->populator->populate($person, $user);
+
+        self::assertEquals('24', $person->getAddress()->getStreetNo());
+    }
+}

--- a/tests/Property/PropertyValueExtractorTest.php
+++ b/tests/Property/PropertyValueExtractorTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neusta\ConverterBundle\Tests\Property;
+
+use Neusta\ConverterBundle\Exception\PropertyException;
+use Neusta\ConverterBundle\Property\PropertyValueExtractor;
+use Neusta\ConverterBundle\Tests\Fixtures\Model\Address;
+use Neusta\ConverterBundle\Tests\Fixtures\Model\User;
+use PHPUnit\Framework\TestCase;
+
+class PropertyValueExtractorTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function testValueExtractingForUser(): void
+    {
+        $address = (new Address())
+            ->setCity('Bremen');
+        $user = (new User())
+            ->setFirstname('Max')
+            ->setUuid(17)
+            ->setAddress($address);
+
+        self::assertEquals('Max', PropertyValueExtractor::extractValue($user, 'firstname'));
+        self::assertEquals(17, PropertyValueExtractor::extractValue($user, 'uuid'));
+        self::assertEquals(
+            'Bremen',
+            PropertyValueExtractor::extractValue(PropertyValueExtractor::extractValue($user, 'address'), 'city')
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function testValueExtractingForUser_exceptional_case(): void
+    {
+        $address = (new Address())
+            ->setCity('Bremen');
+        $user = (new User())
+            ->setFirstname('Max')
+            ->setUuid(17)
+            ->setAddress($address);
+
+        $this->expectException(PropertyException::class);
+        $this->expectExceptionMessageMatches("/Property Exception <street>(.*)/");
+        self::assertEquals(
+            'Bremen',
+            PropertyValueExtractor::extractValue(PropertyValueExtractor::extractValue($user, 'address'), 'street')
+        );
+    }
+}

--- a/tests/app/config/services.yaml
+++ b/tests/app/config/services.yaml
@@ -17,14 +17,6 @@ services:
             $populators:
                 - '@Neusta\ConverterBundle\Tests\Fixtures\Populator\PersonNamePopulator'
 
-    test.address.converter: &test-address-converter
-        parent: 'neusta_converter.default_converter'
-        public: true
-        arguments:
-            $factory: '@Neusta\ConverterBundle\Tests\Fixtures\Factory\AddressFactory'
-            $populators:
-                - '@Neusta\ConverterBundle\Tests\Fixtures\Populator\AddressPopulator'
-
     test.person.converter.with.cache:
         <<: *test-person-converter
 
@@ -34,6 +26,14 @@ services:
         arguments:
             $inner: '@.inner'
             $cacheManagement: '@user.cache_management'
+
+    test.address.converter:
+        parent: 'neusta_converter.default_converter'
+        public: true
+        arguments:
+            $factory: '@Neusta\ConverterBundle\Tests\Fixtures\Factory\AddressFactory'
+            $populators:
+                - '@Neusta\ConverterBundle\Tests\Fixtures\Populator\AddressPopulator'
 
     Neusta\ConverterBundle\Tests\Fixtures\Populator\PersonNamePopulator: ~
     Neusta\ConverterBundle\Tests\Fixtures\Populator\AddressPopulator: ~

--- a/tests/app/config/services.yaml
+++ b/tests/app/config/services.yaml
@@ -17,6 +17,14 @@ services:
             $populators:
                 - '@Neusta\ConverterBundle\Tests\Fixtures\Populator\PersonNamePopulator'
 
+    test.address.converter: &test-address-converter
+        parent: 'neusta_converter.default_converter'
+        public: true
+        arguments:
+            $factory: '@Neusta\ConverterBundle\Tests\Fixtures\Factory\AddressFactory'
+            $populators:
+                - '@Neusta\ConverterBundle\Tests\Fixtures\Populator\AddressPopulator'
+
     test.person.converter.with.cache:
         <<: *test-person-converter
 
@@ -28,7 +36,33 @@ services:
             $cacheManagement: '@user.cache_management'
 
     Neusta\ConverterBundle\Tests\Fixtures\Populator\PersonNamePopulator: ~
-    
+    Neusta\ConverterBundle\Tests\Fixtures\Populator\AddressPopulator: ~
+
+    test.person.address.populator:
+        parent: 'neusta_converter.converter_populator'
+        public: true
+        arguments:
+            $converter: '@test.address.converter'
+            $sourcePropertyName: 'address'
+            $targetPropertyName: 'address'
+
+    test.person.wrong.source.type.populator:
+        parent: 'neusta_converter.converter_populator'
+        public: true
+        arguments:
+            $converter: '@test.address.converter'
+            $sourcePropertyName: 'fieldWithUnknownType'
+            $targetPropertyName: 'address'
+
+    test.person.wrong.converter.populator:
+        parent: 'neusta_converter.converter_populator'
+        public: true
+        arguments:
+            $converter: '@test.person.converter' # wrong converter for testing
+            $sourcePropertyName: 'address'
+            $targetPropertyName: 'address'
+
+
     test.person.fullName.populator:
         parent: 'neusta_converter.same_property_populator'
         public: true
@@ -36,6 +70,7 @@ services:
             $propertyName: 'fullName'
 
     Neusta\ConverterBundle\Tests\Fixtures\Factory\PersonFactory: ~
+    Neusta\ConverterBundle\Tests\Fixtures\Factory\AddressFactory: ~
 
     Neusta\ConverterBundle\Tests\Fixtures\CacheManagement\UserKeyFactory: ~
 


### PR DESCRIPTION
The first try is to be optimistic:

**source** property and **target** property are well-defined and the converter **can** convert them.
If not it will throw a **Population Exception** and show which population failed and what' the internal reason by wrapping the Throwable object.

The other changes came by phpstan and cs-fixer.

Some code blocks are very similar...think about a better solution for it.