### PR TITLE
New ConverterSelector strategy

### DIFF
--- a/src/Converter/StrategicConverter.php
+++ b/src/Converter/StrategicConverter.php
@@ -22,7 +22,6 @@ final class StrategicConverter implements Converter
      * @param ConverterSelector<TSource, TContext> $selector
      */
     public function __construct(
-        private array $converters,
         private ConverterSelector $selector
     ) {
     }
@@ -35,10 +34,6 @@ final class StrategicConverter implements Converter
      */
     public function convert(object $source, ?object $ctx = null): object
     {
-        $selectedConverterKey = $this->selector->selectConverter($source, $ctx);
-        if (array_key_exists($selectedConverterKey, $this->converters)) {
-            return $this->converters[$selectedConverterKey]->convert($source, $ctx);
-        }
-        throw new ConverterException(sprintf("No converter found for key <%s>", $selectedConverterKey));
+        return $this->selector->selectConverter($source, $ctx)->convert($source, $ctx);
     }
 }

--- a/src/Converter/Strategy/ConverterSelector.php
+++ b/src/Converter/Strategy/ConverterSelector.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Neusta\ConverterBundle\Converter\Strategy;
 
+use Neusta\ConverterBundle\Converter;
+use Neusta\ConverterBundle\Exception\ConverterException;
+
 /**
  * @template TSource of object
  * @template TContext of object|null
@@ -13,6 +16,7 @@ interface ConverterSelector
     /**
      * @param TSource $source
      * @param TContext $ctx
+     * @throws ConverterException
      */
-    public function selectConverter(object $source, ?object $ctx = null): string;
+    public function selectConverter(object $source, ?object $ctx = null): Converter;
 }

--- a/src/Converter/Strategy/GenericConverterSelector.php
+++ b/src/Converter/Strategy/GenericConverterSelector.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Neusta\ConverterBundle\Converter\Strategy;
+
+use Neusta\ConverterBundle\Converter;
+use Neusta\ConverterBundle\Converter\Context\GenericContext;
+use Neusta\ConverterBundle\Exception\ConverterException;
+
+/**
+ * @template TSource of object
+ * @implements ConverterSelector<TSource, GenericContext>
+ */
+class GenericConverterSelector implements ConverterSelector
+{
+    /**
+     * @param array<Converter> $converters
+     * @param string $ctxKey
+     */
+    public function __construct(
+        private array $converters,
+        private string $ctxKey,
+    )
+    {
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function selectConverter(object $source, ?object $ctx = null): Converter
+    {
+        $selectedConverterKey = '';
+        if ($ctx->hasKey($this->ctxKey)) {
+            $selectedConverterKey = $ctx->getValue($this->ctxKey);
+        }
+
+        if (array_key_exists($selectedConverterKey,$this->converters)) {
+            return $this->converters[$selectedConverterKey];
+        }
+        throw new ConverterException(sprintf("No converter found for key <%s>", $selectedConverterKey));
+    }
+}

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -98,6 +98,8 @@ final class Configuration implements ConfigurationInterface
                         ->validate()
                             ->ifTrue(fn (array $c) => empty($c['populators']) && empty($c['properties']))
                             ->thenInvalid('At least one "populator" or "property" must be defined.')
+                            ->ifTrue(fn (array $c) => empty($c['selector']) && empty($c['target_factory']))
+                            ->thenInvalid('At least one "selector" or "target_factory" must be defined.')
                         ->end()
                     ->end()
                 ->end()

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -5,27 +5,69 @@ declare(strict_types=1);
 namespace Neusta\ConverterBundle\DependencyInjection;
 
 use Neusta\ConverterBundle\Converter\GenericConverter;
+use Neusta\ConverterBundle\DependencyInjection\Converter\ConverterFactory;
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 
 final class Configuration implements ConfigurationInterface
 {
+    /** @var list<ConverterFactory> */
+    private array $converterFactories;
+
+    /**
+     * @param list<ConverterFactory> $converterFactories
+     */
+    public function __construct(array $converterFactories)
+    {
+        $this->converterFactories = $converterFactories;
+    }
+
     public function getConfigTreeBuilder(): TreeBuilder
     {
         $treeBuilder = new TreeBuilder('neusta_converter');
         $rootNode = $treeBuilder->getRootNode();
 
         $this->addConverterSection($rootNode);
+        $this->addDeprecatedConverterSection($rootNode);
 
         return $treeBuilder;
     }
 
     private function addConverterSection(ArrayNodeDefinition $rootNode): void
     {
+        $converterNodeBuilder = $rootNode
+            //->fixXmlConfig('converter') // Todo: only possible once deprecated config got removed
+            ->children()
+                ->arrayNode('converters')
+                    ->info('Converter configuration')
+                    ->normalizeKeys(false)
+                    ->useAttributeAsKey('name')
+                    ->arrayPrototype()
+        ;
+
+        foreach ($this->converterFactories as $factory) {
+            $factory->addConfiguration($converterNodeBuilder->children()->arrayNode($factory->getKey()));
+        }
+
+        $converterNodeBuilder
+            ->validate()
+                ->ifTrue(fn ($v) => \count($v) > 1)
+                ->thenInvalid('You cannot set multiple converter types for the same converter.')
+            ->end()
+            ->validate()
+                ->ifEmpty()
+                ->thenInvalid('You must set a converter definition for the converter.')
+            ->end()
+        ;
+    }
+
+    private function addDeprecatedConverterSection(ArrayNodeDefinition $rootNode): void
+    {
         $rootNode
             ->children()
                 ->arrayNode('converter')
+                    ->setDeprecated('teamneusta/converter-bundle', '1.0', 'Please use "neusta_converter.converters" instead.')
                     ->info('Converter configuration')
                     ->normalizeKeys(false)
                     ->useAttributeAsKey('name')
@@ -34,16 +76,16 @@ final class Configuration implements ConfigurationInterface
                         ->fixXmlConfig('property', 'properties')
                         ->children()
                             ->scalarNode('converter')
-                                ->info('Class name of the "Converter" implementation')
+                                ->info('Class name of the Converter implementation')
                                 ->defaultValue(GenericConverter::class)
                             ->end()
                             ->scalarNode('target_factory')
-                                ->info('Service id of the "TargetFactory"')
+                                ->info('Service id of the TargetFactory')
                                 ->isRequired()
                                 ->cannotBeEmpty()
                             ->end()
                             ->arrayNode('populators')
-                                ->info('Service ids of the "Populator"s')
+                                ->info('Service ids of the Populator\'s')
                                 ->prototype('scalar')->end()
                             ->end()
                             ->arrayNode('properties')

--- a/src/DependencyInjection/Converter/ConverterFactory.php
+++ b/src/DependencyInjection/Converter/ConverterFactory.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neusta\ConverterBundle\DependencyInjection\Converter;
+
+use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+interface ConverterFactory
+{
+    /**
+     * @return non-empty-string
+     */
+    public function getKey(): string;
+
+    public function addConfiguration(ArrayNodeDefinition $node): void;
+
+    /**
+     * @param array<string, mixed> $config
+     */
+    public function create(ContainerBuilder $container, string $id, array $config): void;
+}

--- a/src/DependencyInjection/Converter/GenericConverterFactory.php
+++ b/src/DependencyInjection/Converter/GenericConverterFactory.php
@@ -24,10 +24,11 @@ final class GenericConverterFactory implements ConverterFactory
             ->fixXmlConfig('populator')
             ->fixXmlConfig('property', 'properties')
             ->children()
+                ->scalarNode('selector')
+                    ->info('Service id of the ConverterSelector')
+                ->end()
                 ->scalarNode('target_factory')
                     ->info('Service id of the TargetFactory')
-                    ->isRequired()
-                    ->cannotBeEmpty()
                 ->end()
                 ->arrayNode('populators')
                     ->info('Service ids of the Populator\'s')
@@ -43,6 +44,8 @@ final class GenericConverterFactory implements ConverterFactory
             ->validate()
                 ->ifTrue(fn (array $c) => empty($c['populators']) && empty($c['properties']))
                 ->thenInvalid('At least one "populator" or "property" must be defined.')
+                ->ifTrue(fn (array $c) => empty($c['selector']) && empty($c['target_factory']) || (!empty($c['selector']) && !empty($c['target_factory'])))
+                ->thenInvalid('Exactly one "selector" or "target_factory" must be defined.')
             ->end();
     }
 

--- a/src/DependencyInjection/Converter/GenericConverterFactory.php
+++ b/src/DependencyInjection/Converter/GenericConverterFactory.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neusta\ConverterBundle\DependencyInjection\Converter;
+
+use Neusta\ConverterBundle\Converter;
+use Neusta\ConverterBundle\Converter\GenericConverter;
+use Neusta\ConverterBundle\Populator\PropertyMappingPopulator;
+use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+final class GenericConverterFactory implements ConverterFactory
+{
+    public function getKey(): string
+    {
+        return 'generic';
+    }
+
+    public function addConfiguration(ArrayNodeDefinition $node): void
+    {
+        $node
+            ->fixXmlConfig('populator')
+            ->fixXmlConfig('property', 'properties')
+            ->children()
+                ->scalarNode('target_factory')
+                    ->info('Service id of the TargetFactory')
+                    ->isRequired()
+                    ->cannotBeEmpty()
+                ->end()
+                ->arrayNode('populators')
+                    ->info('Service ids of the Populator\'s')
+                    ->prototype('scalar')->end()
+                ->end()
+                ->arrayNode('properties')
+                    ->info('Mapping of source properties (value) to target properties (key)')
+                    ->normalizeKeys(false)
+                    ->useAttributeAsKey('target')
+                    ->prototype('scalar')->end()
+                ->end()
+            ->end()
+            ->validate()
+                ->ifTrue(fn (array $c) => empty($c['populators']) && empty($c['properties']))
+                ->thenInvalid('At least one "populator" or "property" must be defined.')
+            ->end();
+    }
+
+    public function create(ContainerBuilder $container, string $id, array $config): void
+    {
+        foreach ($config['properties'] ?? [] as $targetProperty => $sourceProperty) {
+            $config['populators'][] = $propertyPopulatorId = "{$id}.populator.{$targetProperty}";
+            $container->register($propertyPopulatorId, PropertyMappingPopulator::class)
+                ->setArguments([
+                    '$targetProperty' => $targetProperty,
+                    '$sourceProperty' => $sourceProperty ?? $targetProperty,
+                    '$accessor' => new Reference('property_accessor'),
+                ]);
+        }
+
+        $container->registerAliasForArgument($id, Converter::class, $this->ensureSuffix($id, 'Converter'));
+        $container->register($id, GenericConverter::class)
+            ->setPublic(true)
+            ->setArguments([
+                '$factory' => new Reference($config['target_factory']),
+                '$populators' => array_map(
+                    static fn (string $populator) => new Reference($populator),
+                    $config['populators'],
+                ),
+            ]);
+    }
+
+    private function ensureSuffix(string $value, string $suffix): string
+    {
+        return str_ends_with($value, $suffix) ? $value : $value . $suffix;
+    }
+}

--- a/src/NeustaConverterBundle.php
+++ b/src/NeustaConverterBundle.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Neusta\ConverterBundle;
 
+use Neusta\ConverterBundle\DependencyInjection\Converter\GenericConverterFactory;
+use Neusta\ConverterBundle\DependencyInjection\NeustaConverterExtension;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 class NeustaConverterBundle extends Bundle
@@ -11,5 +14,15 @@ class NeustaConverterBundle extends Bundle
     public function getPath(): string
     {
         return __DIR__;
+    }
+
+    public function build(ContainerBuilder $container): void
+    {
+        parent::build($container);
+
+        $extension = $container->getExtension('neusta_converter');
+        \assert($extension instanceof NeustaConverterExtension);
+
+        $extension->addConverterFactory(new GenericConverterFactory());
     }
 }

--- a/tests/Converter/StrategicConverterTest.php
+++ b/tests/Converter/StrategicConverterTest.php
@@ -32,16 +32,13 @@ class StrategicConverterTest extends TestCase
         $this->converter = $this->prophesize(Converter::class);
 
         $this->strategyHandler = new StrategicConverter(
-            [
-                'testKey' => $this->converter->reveal(),
-            ],
             $this->selector->reveal(),
         );
 
         $user = new User();
         $person = new Person();
 
-        $this->selector->selectConverter($user, null)->willReturn('testKey');
+        $this->selector->selectConverter($user, null)->willReturn($this->converter->reveal());
         $this->converter->convert($user, null)->willReturn($person)->shouldBeCalled();
 
         $this->strategyHandler->convert($user);
@@ -54,20 +51,16 @@ class StrategicConverterTest extends TestCase
         $this->converter = $this->prophesize(Converter::class);
 
         $this->strategyHandler = new StrategicConverter(
-            [
-                'testKey' => $this->converter->reveal(),
-            ],
             $this->selector->reveal(),
         );
 
         $user = new User();
         $person = new Person();
 
-        $this->selector->selectConverter($user, null)->willReturn('otherKey');
+        $this->selector->selectConverter($user, null)->willThrow(ConverterException::class);
         $this->converter->convert($user, null)->willReturn($person)->shouldNotBeCalled();
 
         $this->expectException(ConverterException::class);
-        $this->expectExceptionMessage("No converter found for key <otherKey>");
 
         $this->strategyHandler->convert($user);
 

--- a/tests/Converter/Strategy/GenericConverterSelectorTest.php
+++ b/tests/Converter/Strategy/GenericConverterSelectorTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Neusta\ConverterBundle\Tests\Converter\Strategy;
+
+use Neusta\ConverterBundle\Converter;
+use Neusta\ConverterBundle\Converter\Context\GenericContext;
+use Neusta\ConverterBundle\Converter\Strategy\ConverterSelector;
+use Neusta\ConverterBundle\Converter\Strategy\GenericConverterSelector;
+use Neusta\ConverterBundle\Exception\ConverterException;
+use Neusta\ConverterBundle\Tests\Fixtures\Model\User;
+use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Prophecy\Prophecy\ObjectProphecy;
+use function PHPUnit\Framework\assertSame;
+
+class GenericConverterSelectorTest extends TestCase
+{
+    use ProphecyTrait;
+
+    private GenericContext $ctx;
+
+    private ConverterSelector $selector;
+
+    /** @var Converter|ObjectProphecy */
+    private $converter;
+
+    protected function setUp(): void
+    {
+        $this->converter = $this->prophesize(Converter::class);
+        $this->selector = new GenericConverterSelector(
+            [
+                'converter_1' => $this->converter->reveal(),
+            ],
+            'selectionKey'
+        );
+    }
+
+    public function testSelectConverter_find_converter(): void
+    {
+        $this->ctx = new GenericContext();
+        $this->ctx->setValue('selectionKey', 'converter_1');
+
+        assertSame($this->converter->reveal(), $this->selector->selectConverter(new User(), $this->ctx));
+    }
+
+    public function testSelectConverter_no_converter_found(): void
+    {
+        $this->expectException(ConverterException::class);
+        $this->expectExceptionMessage('No converter found for key <unknown_converter>');
+
+        $this->ctx = new GenericContext();
+        $this->ctx->setValue('selectionKey', 'unknown_converter');
+
+        $this->selector->selectConverter(new User(), $this->ctx);
+    }
+}

--- a/tests/DependencyInjection/NeustaConverterExtensionTest.php
+++ b/tests/DependencyInjection/NeustaConverterExtensionTest.php
@@ -6,12 +6,14 @@ namespace Neusta\ConverterBundle\Tests\DependencyInjection;
 
 use Neusta\ConverterBundle\Converter;
 use Neusta\ConverterBundle\Converter\GenericConverter;
+use Neusta\ConverterBundle\Converter\Strategy\GenericConverterSelector;
 use Neusta\ConverterBundle\DependencyInjection\NeustaConverterExtension;
 use Neusta\ConverterBundle\NeustaConverterBundle;
 use Neusta\ConverterBundle\Populator\PropertyMappingPopulator;
 use Neusta\ConverterBundle\Tests\Fixtures\Model\PersonFactory;
 use Neusta\ConverterBundle\Tests\Fixtures\Populator\PersonNamePopulator;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
 use Symfony\Component\DependencyInjection\Reference;
@@ -81,6 +83,35 @@ class NeustaConverterExtensionTest extends TestCase
         self::assertSame('ageInYears', $ageInYearsPopulator->getArgument('$targetProperty'));
         self::assertSame('age', $ageInYearsPopulator->getArgument('$sourceProperty'));
     }
+
+    public function test_with_selector_config(): void
+    {
+        $this->expectException(InvalidConfigurationException::class);
+        $container = $this->buildContainer([
+            'converter' => [
+                'foobar' => [
+                    'selector' => GenericConverterSelector::class
+                ],
+            ],
+        ]);
+
+        // converter
+        $converter = $container->getDefinition('foobar');
+        self::assertSame(GenericConverter::class, $converter->getClass());
+        self::assertTrue($converter->isPublic());
+        self::assertTrue($container->hasAlias(Converter::class . ' $foobarConverter'));
+    }
+    public function test_with_insufficient_config(): void
+    {
+        $this->expectException(InvalidConfigurationException::class);
+        $container = $this->buildContainer([
+            'converter' => [
+                'foobar' => [
+                ],
+            ],
+        ]);
+    }
+
 
     private static function assertIsReference(string $expected, mixed $actual): void
     {

--- a/tests/Selector/DefaultConverterSelector.php
+++ b/tests/Selector/DefaultConverterSelector.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Neusta\ConverterBundle\Tests\Selector;
+
+use Neusta\ConverterBundle\Converter;
+use Neusta\ConverterBundle\Converter\Strategy\ConverterSelector;
+use Neusta\ConverterBundle\Exception\ConverterException;
+
+/**
+ *
+ */
+class DefaultConverterSelector implements ConverterSelector
+{
+    /**
+     * @param array<string, Converter> $converters
+     */
+    public function __construct(
+        private array $converters,
+    )
+    {
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function selectConverter(object $source, ?object $ctx = null): Converter
+    {
+        if ($ctx->hasKey('converterKey')) {
+            return $this->converters[$ctx->getKey('converterKey')]->convert($source, $ctx);
+        }
+        throw new ConverterException(sprintf("No converter found for key <%s>", $selectedConverterKey));
+    }
+}

--- a/tests/app/config/packages/neusta_converter.yaml
+++ b/tests/app/config/packages/neusta_converter.yaml
@@ -1,10 +1,10 @@
 neusta_converter:
-  converter:
+  converters:
     test.person.converter:
-#      converter: Neusta\ConverterBundle\Converter\GenericConverter
-      target_factory: Neusta\ConverterBundle\Tests\Fixtures\Model\PersonFactory
-      populators:
-        - Neusta\ConverterBundle\Tests\Fixtures\Populator\PersonNamePopulator
-#      properties:
-#        fullName: ~
-#        age: ageInYears
+      generic:
+        target_factory: Neusta\ConverterBundle\Tests\Fixtures\Model\PersonFactory
+        populators:
+          - Neusta\ConverterBundle\Tests\Fixtures\Populator\PersonNamePopulator
+#        properties:
+#          fullName: ~
+#          age: ageInYears


### PR DESCRIPTION
Find the right Converter not only a string.

The idea of this PR is to change the implementation of ConverterSelector and return Converter instead of mapping types (e.g. string or array_keys)