### PR TITLE
refactor: change order of template annotations

### DIFF
--- a/src/Converter.php
+++ b/src/Converter.php
@@ -7,8 +7,8 @@ namespace Neusta\ConverterBundle;
 use Neusta\ConverterBundle\Exception\ConverterException;
 
 /**
- * @template TSource of object
  * @template TTarget of object
+ * @template TSource of object
  * @template TContext of object|null
  */
 interface Converter

--- a/src/Converter/GenericConverter.php
+++ b/src/Converter/GenericConverter.php
@@ -9,8 +9,8 @@ use Neusta\ConverterBundle\Populator;
 use Neusta\ConverterBundle\TargetFactory;
 
 /**
- * @template TSource of object
  * @template TTarget of object
+ * @template TSource of object
  * @template TContext of object|null
  *
  * @implements Converter<TSource, TTarget, TContext>
@@ -19,7 +19,7 @@ final class GenericConverter implements Converter
 {
     /**
      * @param TargetFactory<TTarget, TContext>             $factory
-     * @param array<Populator<TSource, TTarget, TContext>> $populators
+     * @param array<Populator<TTarget, TSource, TContext>> $populators
      */
     public function __construct(
         private TargetFactory $factory,

--- a/src/Converter/StrategicConverter.php
+++ b/src/Converter/StrategicConverter.php
@@ -9,8 +9,8 @@ use Neusta\ConverterBundle\Converter\Strategy\ConverterSelector;
 use Neusta\ConverterBundle\Exception\ConverterException;
 
 /**
- * @template TSource of object
  * @template TTarget of object
+ * @template TSource of object
  * @template TContext of object|null
  *
  * @implements Converter<TSource, TTarget, TContext>
@@ -18,7 +18,7 @@ use Neusta\ConverterBundle\Exception\ConverterException;
 final class StrategicConverter implements Converter
 {
     /**
-     * @param array<string, Converter<TSource, TTarget, TContext>> $converters
+     * @param array<string, Converter<TTarget, TSource, TContext>> $converters
      * @param ConverterSelector<TSource, TContext>                 $selector
      */
     public function __construct(

--- a/src/Populator.php
+++ b/src/Populator.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace Neusta\ConverterBundle;
 
 /**
- * @template TSource of object
  * @template TTarget of object
+ * @template TSource of object
  * @template TContext of object|null
  */
 interface Populator


### PR DESCRIPTION
The populator seems inintuitive order of templates.

Maybe change them, and to be consistent, change the order for converter as well ?!