### PR TITLE
`ArrayPropertyMappingPopulator`: support `null` as source array property value

### DIFF
--- a/src/Populator/ArrayPropertyMappingPopulator.php
+++ b/src/Populator/ArrayPropertyMappingPopulator.php
@@ -45,12 +45,17 @@ final class ArrayPropertyMappingPopulator implements Populator
     public function populate(object $target, object $source, ?object $ctx = null): void
     {
         try {
-            $unwrappedArray = array_map(
-                fn ($item) => null !== $this->sourceArrayItemProperty
-                    ? $this->arrayItemAccessor->getValue($item, $this->sourceArrayItemProperty)
-                    : $item,
-                $this->accessor->getValue($source, $this->sourceArrayProperty),
-            );
+            $sourceArrayPropertyValues = $this->accessor->getValue($source, $this->sourceArrayProperty);
+
+            $unwrappedArray = [];
+            if (!empty($sourceArrayPropertyValues)) {
+                $unwrappedArray = array_map(
+                    fn ($item) => null !== $this->sourceArrayItemProperty
+                        ? $this->arrayItemAccessor->getValue($item, $this->sourceArrayItemProperty)
+                        : $item,
+                    $sourceArrayPropertyValues,
+                );
+            }
 
             $this->accessor->setValue(
                 $target,

--- a/src/Populator/ArrayPropertyMappingPopulator.php
+++ b/src/Populator/ArrayPropertyMappingPopulator.php
@@ -48,7 +48,7 @@ final class ArrayPropertyMappingPopulator implements Populator
             $sourceArrayPropertyValues = $this->accessor->getValue($source, $this->sourceArrayProperty);
 
             $unwrappedArray = [];
-            if (is_array($sourceArrayPropertyValues) && [] !== $sourceArrayPropertyValues) {
+            if (\is_array($sourceArrayPropertyValues) && [] !== $sourceArrayPropertyValues) {
                 $unwrappedArray = array_map(
                     fn ($item) => null !== $this->sourceArrayItemProperty
                         ? $this->arrayItemAccessor->getValue($item, $this->sourceArrayItemProperty)

--- a/src/Populator/ArrayPropertyMappingPopulator.php
+++ b/src/Populator/ArrayPropertyMappingPopulator.php
@@ -48,7 +48,7 @@ final class ArrayPropertyMappingPopulator implements Populator
             $sourceArrayPropertyValues = $this->accessor->getValue($source, $this->sourceArrayProperty);
 
             $unwrappedArray = [];
-            if (!empty($sourceArrayPropertyValues)) {
+            if (is_array($sourceArrayPropertyValues) && [] !== $sourceArrayPropertyValues) {
                 $unwrappedArray = array_map(
                     fn ($item) => null !== $this->sourceArrayItemProperty
                         ? $this->arrayItemAccessor->getValue($item, $this->sourceArrayItemProperty)

--- a/tests/Fixtures/Model/User.php
+++ b/tests/Fixtures/Model/User.php
@@ -17,8 +17,8 @@ class User
     /** @var array<string> */
     private array $favouriteMovies;
 
-    /** @var array<Hobby> */
-    private array $hobbies;
+    /** @var array<Hobby>|null */
+    private ?array $hobbies;
 
     /** @var array<Phone> */
     private array $phones;
@@ -119,12 +119,12 @@ class User
         return $this;
     }
 
-    public function getHobbies(): array
+    public function getHobbies(): ?array
     {
         return $this->hobbies;
     }
 
-    public function setHobbies(array $hobbies): self
+    public function setHobbies(?array $hobbies): self
     {
         $this->hobbies = $hobbies;
 

--- a/tests/Populator/ArrayPropertyMappingPopulatorTest.php
+++ b/tests/Populator/ArrayPropertyMappingPopulatorTest.php
@@ -46,4 +46,15 @@ class ArrayPropertyMappingPopulatorTest extends TestCase
 
         self::assertEquals(['reading', 'swimming', 'computers'], $person->getActivities());
     }
+
+    public function test_populateWithInnerProperty_is_null(): void
+    {
+        $populator = new ArrayPropertyMappingPopulator('activities', 'hobbies', 'label');
+        $user = (new User())->setHobbies(null);
+        $person = new Person();
+
+        $populator->populate($person, $user);
+
+        self::assertEmpty($person->getActivities());
+    }
 }


### PR DESCRIPTION
 There is a missing failsafe check for cases if source property value returned is null (and no regular array).
Now, it is checked before and set to empty array for the target object.

A default "strategy" as for `PropertyMappingPopulator` makes IMHO no sense.