### PR TITLE
Bump minimum PHP version to 8.1

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -19,10 +19,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - php-version: "8.0"
+          - php-version: "8.1"
             dependencies: "lowest"
-          - php-version: "8.0"
-            dependencies: "highest"
           - php-version: "8.1"
             dependencies: "highest"
           - php-version: "8.2"

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     }
   ],
   "require": {
-    "php": "~8.0.0 || ~8.1.0 || ~8.2.0 || ~8.3.0",
+    "php": "~8.1.0 || ~8.2.0 || ~8.3.0",
     "symfony/config": "^5.4 || ^6.2 || ^7.0",
     "symfony/dependency-injection": "^5.4 || ^6.2 || ^7.0",
     "symfony/framework-bundle": "^5.4 || ^6.2 || ^7.0",


### PR DESCRIPTION
PHP 8.0 is EOL since November 2023.