### PR TITLE
New config property "converterSuffix"

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -30,7 +30,7 @@ final class Configuration implements ConfigurationInterface
             ->children()
                 ->scalarNode('converterSuffix')
                     ->info('consolidated suffix for all converters')
-                    ->defaultValue('')
+                    ->defaultValue('Converter')
                 ->end()
                 ->arrayNode('converter')
                     ->info('Converter configuration')

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -28,7 +28,7 @@ final class Configuration implements ConfigurationInterface
     {
         $rootNode
             ->children()
-                ->scalarNode('converterSuffix')
+                ->scalarNode('converter_suffix')
                     ->info('consolidated suffix for all converters')
                     ->defaultValue('Converter')
                 ->end()

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -28,6 +28,10 @@ final class Configuration implements ConfigurationInterface
     {
         $rootNode
             ->children()
+                ->scalarNode('converterSuffix')
+                    ->info('consolidated suffix for all converters')
+                    ->defaultValue('')
+                ->end()
                 ->arrayNode('converter')
                     ->info('Converter configuration')
                     ->normalizeKeys(false)

--- a/src/DependencyInjection/NeustaConverterExtension.php
+++ b/src/DependencyInjection/NeustaConverterExtension.php
@@ -29,7 +29,7 @@ final class NeustaConverterExtension extends ConfigurableExtension
         $loader->load('services.yaml');
 
         foreach ($mergedConfig['converter'] as $converterId => $converter) {
-            $this->registerConverterConfiguration($converterId, $converter, $container);
+            $this->registerConverterConfiguration($converterId, $converter, $container, $mergedConfig['converterSuffix']);
         }
 
         foreach ($mergedConfig['populator'] as $populatorId => $populator) {
@@ -40,7 +40,7 @@ final class NeustaConverterExtension extends ConfigurableExtension
     /**
      * @param array<string, mixed> $config
      */
-    private function registerConverterConfiguration(string $id, array $config, ContainerBuilder $container): void
+    private function registerConverterConfiguration(string $id, array $config, ContainerBuilder $container, ?string $converterSuffix): void
     {
         $targetFactoryId = $config['target_factory'] ?? "{$id}.target_factory";
         if (!isset($config['target_factory'])) {
@@ -77,7 +77,7 @@ final class NeustaConverterExtension extends ConfigurableExtension
                 ]);
         }
 
-        $container->registerAliasForArgument($id, Converter::class, $this->appendSuffix($id, 'Converter'));
+        $container->registerAliasForArgument($id, Converter::class, $this->appendSuffix($id, $converterSuffix ?? ''));
         $container->register($id, $config['converter'])
             ->setPublic(true)
             ->setArguments([

--- a/tests/DependencyInjection/NeustaConverterExtensionTest.php
+++ b/tests/DependencyInjection/NeustaConverterExtensionTest.php
@@ -32,6 +32,7 @@ class NeustaConverterExtensionTest extends AbstractExtensionTestCase
     public function test_with_generic_converter(): void
     {
         $this->load([
+            'converterSuffix' => 'Converter',
             'converter' => [
                 'foobar' => [
                     'target_factory' => PersonFactory::class,
@@ -122,6 +123,7 @@ class NeustaConverterExtensionTest extends AbstractExtensionTestCase
     public function test_with_mapped_properties(): void
     {
         $this->load([
+            'converterSuffix' => 'Converter',
             'converter' => [
                 'foobar' => [
                     'target_factory' => PersonFactory::class,
@@ -180,6 +182,7 @@ class NeustaConverterExtensionTest extends AbstractExtensionTestCase
     public function test_with_mapped_context(): void
     {
         $this->load([
+            'converterSuffix' => 'Converter',
             'converter' => [
                 'foobar' => [
                     'target_factory' => PersonFactory::class,


### PR DESCRIPTION
This property will be introduced to enable backwards compatibilty to "older" converter declarations.