### PR TITLE
Remove unused `data-bundle` attribute from accordion items in service container twig template

### DIFF
--- a/templates/debug/_includes/service_container.html.twig
+++ b/templates/debug/_includes/service_container.html.twig
@@ -8,7 +8,7 @@
         {% include '@NeustaConverter/debug/_partials/search_container.html.twig' %}
         <div class="accordion">
             {% for id, service in services %}
-                <details class="accordion-item" data-bundle="{{ service.bundleName }}">
+                <details class="accordion-item">
                     <summary id="{{ id }}" type="{{ service.type }}" class="type-{{ service.type }}">{{ id }}</summary>
                     <div class="accordion-content">
                         <table class="argument-table">


### PR DESCRIPTION
Otherwise, I get the following error when running `console neusta:converter:debug --out=converter-overview.html`:

![image](https://github.com/user-attachments/assets/bbf41671-60e8-4e78-9a83-cd3af37fd615)
