### PR TITLE
Remove unused attribute "data-bundle" in service_container

### DIFF
--- a/templates/debug/_includes/service_container.html.twig
+++ b/templates/debug/_includes/service_container.html.twig
@@ -8,7 +8,7 @@
         {% include '@NeustaConverter/debug/_partials/search_container.html.twig' %}
         <div class="accordion">
             {% for id, service in services %}
-                <details class="accordion-item" data-bundle="{{ service.bundleName }}">
+                <details class="accordion-item">
                     <summary id="{{ id }}" type="{{ service.type }}" class="type-{{ service.type }}">{{ id }}</summary>
                     <div class="accordion-content">
                         <table class="argument-table">


### PR DESCRIPTION
This leads to an error because the property bundle name of the ServiceInfo has already been removed.