### PR TITLE
[Symfony Translation] move contracts dependency to dev section

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,8 +24,7 @@
     "symfony/expression-language": "^5.4 || ^6.2 || ^7.0",
     "symfony/framework-bundle": "^5.4 || ^6.2 || ^7.0",
     "symfony/http-kernel": "^5.4 || ^6.2 || ^7.0",
-    "symfony/property-access": "^5.4 || ^6.2 || ^7.0",
-    "symfony/translation": "^5.4 || ^6.2 || ^7.4"
+    "symfony/property-access": "^5.4 || ^6.2 || ^7.0"
   },
   "require-dev": {
     "ergebnis/composer-normalize": "^2.42",
@@ -44,6 +43,7 @@
     "symfony/filesystem": "^5.4 || ^6.2 || ^7.0",
     "symfony/phpunit-bridge": "^5.4 || ^6.2 || ^7.0",
     "symfony/test-pack": "^1.0",
+    "symfony/translation-contracts": "^2.5 || ^3.6",
     "symfony/twig-bundle": "^5.4 || ^6.2 || ^7.0",
     "symfony/yaml": "^5.4 || ^6.2 || ^7.0",
     "twig/twig": "^3.20"


### PR DESCRIPTION
`symfony/translation` were not necessary to be a requirement in our bundle because Translator is an optional feature in our Command.
To use Symfony TranslatorInterface we add `symfony/translation-contracts` in our dev-requirements.